### PR TITLE
Add menu page base classes

### DIFF
--- a/src/Admin/MenuPage.php
+++ b/src/Admin/MenuPage.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Base class for menu or submenu pages.
+ */
+
+namespace OomphInc\Bases\Admin;
+
+class MenuPage extends \OomphInc\Bases\InstantiableEntity {
+
+	protected $title = 'Page';
+	// this dictates whether the page will be a submenu or regular menu page
+	protected $parent = 'options-general.php';
+	protected $capability = 'manage_options';
+	// for top level pages
+	protected $icon = '';
+	protected $position;
+	protected $render; // optional callable used to render the page
+	protected static $shared_hooks = [
+		[ 'admin_menu', 'register_page' ],
+	];
+
+	/**
+	 * Register the admin page for displaying the settings.
+	 *
+	 * @action admin_menu
+	 */
+	function register_page() {
+		$args = [
+			$this->title,
+			$this->title,
+			$this->capability,
+			$this->get_name(),
+			is_callable( $this->render ) ? $this->render : [ $this, 'render' ],
+		];
+		// submenu
+		if ( $this->parent ) {
+			array_unshift( $args, $this->parent );
+			$func = 'add_submenu_page';
+		// regular menu page
+		} else {
+			array_push( $args, $this->icon, $this->position );
+			$func = 'add_menu_page';
+		}
+		call_user_func_array( $func, $args );
+	}
+
+	/**
+	 * Render the page.
+	 */
+	function render() {}
+
+}

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Settings page base class.
+ */
+
+namespace OomphInc\Bases\Admin;
+
+use WP_Forms_API;
+
+class SettingsPage extends MenuPage {
+
+	protected $title = 'Settings';
+	public $form = [];
+	protected static $shared_hooks = [
+		[ 'admin_menu', 'register_page' ],
+		[ 'admin_init', 'register_setting' ],
+	];
+
+	/**
+	 * Retrieve any settings saved to this page.
+	 * @return array settings
+	 */
+	function get_settings() {
+		return get_option( $this->get_name(), [] );
+	}
+
+	/**
+	 * Handle the POST submission of settings from the form.
+	 * @return array processed values
+	 */
+	function process_settings() {
+		WP_Forms_API::process_form( $this->form, $settings_values );
+		return isset( $settings_values ) ? $settings_values : [];
+	}
+
+	/**
+	 * Register a setting for this page.
+	 *
+	 * @action admin_init
+	 */
+	function register_setting() {
+		register_setting( $this->get_name(), $this->get_name(), [ $this, 'process_settings' ] );
+	}
+
+	/**
+	 * Render the settings form page.
+	 */
+	function render() {
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( $this->title ); ?></h1>
+			<form method="post" action="options.php">
+			<?php
+			settings_fields( $this->get_name() );
+			$settings = $this->get_settings();
+			echo WP_Forms_API::render_form( $this->form, $settings );
+			submit_button();
+			?>
+			</form>
+		</div>
+		<?php
+	}
+
+}

--- a/src/InstantiableEntity.php
+++ b/src/InstantiableEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * A base entity for an object that can be instantiated.
+ */
+
+namespace OomphInc\Bases;
+
+class InstantiableEntity extends BaseEntity {
+
+	function __construct( $name, array $properties = [] ) {
+		$this->name = $name;
+		// for convenience, properties can be passed as an array upon instantiation
+		foreach ( $properties as $name => $value ) {
+			$this->$name = $value;
+		}
+		parent::__construct();
+	}
+
+	function get_name() {
+		return $this->name;
+	}
+
+}

--- a/src/Post/Features/SettingsPage.php
+++ b/src/Post/Features/SettingsPage.php
@@ -7,8 +7,6 @@
 
 namespace OomphInc\Bases\Post\Features;
 
-use OomphInc\Bases\Admin\SettingsPage as Page;
-
 // prefix for options
 const OPTIONS_PREFIX = 'CPT_settings_';
 
@@ -21,7 +19,7 @@ trait SettingsPage {
 
 	protected function _init_SettingsPage() {
 		if ( !empty( $this->settings_form ) ) {
-			$this->_page = new Page( OPTIONS_PREFIX . $this->get_post_type(), [
+			$this->_page = new \OomphInc\Bases\Admin\SettingsPage( OPTIONS_PREFIX . $this->get_post_type(), [
 				'parent' => 'edit.php?post_type=' . $this->get_post_type(),
 				'form' => $this->settings_form,
 			] );

--- a/src/Post/Features/SettingsPage.php
+++ b/src/Post/Features/SettingsPage.php
@@ -7,6 +7,8 @@
 
 namespace OomphInc\Bases\Post\Features;
 
+use OomphInc\Bases\Admin\SettingsPage as Page;
+
 // prefix for options
 const OPTIONS_PREFIX = 'CPT_settings_';
 
@@ -15,31 +17,15 @@ const OPTIONS_PREFIX = 'CPT_settings_';
  */
 trait SettingsPage {
 
-	private $_settings_title;
+	private $_page;
 
 	protected function _init_SettingsPage() {
 		if ( !empty( $this->settings_form ) ) {
-			add_action( 'admin_menu', [ $this, '_register_settings_page' ] );
-			add_action( 'admin_init', [ $this, '_register_setting' ] );
-			$this->_settings_title = !empty( $this->settings_title ) ? $this->settings_title : 'Settings';
+			$this->_page = new Page( OPTIONS_PREFIX . $this->get_post_type(), [
+				'parent' => 'edit.php?post_type=' . $this->get_post_type(),
+				'form' => $this->settings_form,
+			] );
 		}
-	}
-	// form fields to display on a settings page under the CPT section in WP Admin
-
-	/**
-	 * Register the admin page for displaying the settings.
-	 *
-	 * @action admin_menu
-	 */
-	function _register_settings_page() {
-		add_submenu_page(
-			'edit.php?post_type=' . $this->get_post_type(),
-			$this->_settings_title,
-			$this->_settings_title,
-			!empty( $this->settings_capability ) ? $this->settings_capability : 'manage_options',
-			OPTIONS_PREFIX . $this->get_post_type(),
-			[ $this, '_render_settings_page' ]
-		);
 	}
 
 	/**
@@ -47,44 +33,7 @@ trait SettingsPage {
 	 * @return array settings
 	 */
 	function get_settings() {
-		return get_option( OPTIONS_PREFIX . $this->get_post_type(), [] );
-	}
-
-	/**
-	 * Handle the POST submission of settings from the form.
-	 * @return array processed values
-	 */
-	function _process_settings() {
-		WP_Forms_API::process_form( $this->settings_form, $settings_values );
-		return isset( $settings_values ) ? $settings_values : [];
-	}
-
-	/**
-	 * Register a setting for this CPT.
-	 *
-	 * @action admin_init
-	 */
-	function _register_setting() {
-		register_setting( OPTIONS_PREFIX . $this->get_post_type(), OPTIONS_PREFIX . $this->get_post_type(), [ $this, '_process_settings' ] );
-	}
-
-	/**
-	 * Render the settings form page.
-	 */
-	function _render_settings_page() {
-		?>
-		<div class="wrap">
-			<h1><?php echo esc_html( $this->_settings_title ); ?></h1>
-			<form method="post" action="options.php">
-			<?php
-			settings_fields( OPTIONS_PREFIX . $this->get_post_type() );
-			$settings = $this->get_settings();
-			echo WP_Forms_API::render_form( $this->settings_form, $settings );
-			submit_button();
-			?>
-			</form>
-		</div>
-		<?php
+		return $this->_page->get_settings();
 	}
 
 }


### PR DESCRIPTION
- adds a new menu page base class, which can be top level or submenu
- creates a derivative settings page class which renders and processes a form on said page
- creates a new 'instantiable' base entity class derived from the singleton-y base class, mainly so that custom post types can create settings pages on the fly

P.S. The more I think about, I feel like this repo should be restructured such that there is (for example) a CPT class which can be instantiated an arbitrary number of times for each post type as opposed to extending the CPT base class and instantiating that once. Most of the time all I fill in for these are the basic CPT properties without any methods, making it rather pointless to be an extended class. For those times when you do wanna add additional methods and hooks, I'm not sure the best way to handle that. I'll keep musing, but in the meantime I need the stuff in this PR for CRE!
