### PR TITLE
Fix instantiation with name

### DIFF
--- a/src/InstantiableEntity.php
+++ b/src/InstantiableEntity.php
@@ -8,6 +8,8 @@ namespace OomphInc\Bases;
 
 class InstantiableEntity extends BaseEntity {
 
+	protected $name;
+
 	function __construct( $name = null, array $properties = [] ) {
 		if ( isset( $name ) ) {
 			$this->name = $name;

--- a/src/InstantiableEntity.php
+++ b/src/InstantiableEntity.php
@@ -8,8 +8,10 @@ namespace OomphInc\Bases;
 
 class InstantiableEntity extends BaseEntity {
 
-	function __construct( $name, array $properties = [] ) {
-		$this->name = $name;
+	function __construct( $name = null, array $properties = [] ) {
+		if ( isset( $name ) ) {
+			$this->name = $name;
+		}
 		// for convenience, properties can be passed as an array upon instantiation
 		foreach ( $properties as $name => $value ) {
 			$this->$name = $value;


### PR DESCRIPTION
This allows name to be optional in the constructor in case it is already set in a derivative class.
